### PR TITLE
Fix web compilation for tests

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,0 +1,5 @@
+targets:
+  $default:
+    sources:
+      exclude:
+        - example/**

--- a/lib/src/client/connection.dart
+++ b/lib/src/client/connection.dart
@@ -14,7 +14,6 @@
 // limitations under the License.
 
 import 'dart:async';
-import 'dart:io';
 
 import 'package:meta/meta.dart';
 
@@ -23,7 +22,9 @@ import 'call.dart';
 import 'options.dart';
 import 'transport/http2_transport.dart';
 import 'transport/transport.dart';
+// ignore: uri_does_not_exist
 import 'transport/xhr_transport_stub.dart'
+    // ignore: uri_does_not_exist
     if (dart.library.html) 'transport/xhr_transport.dart';
 
 enum ConnectionState {


### PR DESCRIPTION
Added the necessary `// ignore: uri_does_not_exist` comments, and filter out the `example` directory from compilation to get rid of module warnings (it contains separate nested packages). 