### PR TITLE
Add docker setup for easier grpc-web example setup

### DIFF
--- a/example/grpc-web/README.md
+++ b/example/grpc-web/README.md
@@ -13,11 +13,14 @@ $ pub global activate webdev
 ```
 
 # Run the sample code
-Follow the instructions for starting the grpc-web example server. The simplest version of this involves running the grpc-web server in a docker container with:
+To run this example you'll need a running GRPC server which implements the echo service. There's a basic implementation
+available in `lib/src/server.dart`. To run this server including an envoy proxy to properly support grpc web:
 
 ```sh
-$ docker-compose up echo-server envoy
+$ docker-compose up -d
 ```
+
+This will launch a envoy server on http://localhost:8080 which will proxy to a dart service container. 
 
 To compile and run the example, assuming you are in the root of the grpc-web
 folder, i.e., .../example/grpc-web/, first get the dependencies by running:

--- a/example/grpc-web/bin/server.dart
+++ b/example/grpc-web/bin/server.dart
@@ -1,0 +1,8 @@
+import 'package:grpc/grpc.dart';
+import 'package:grpc_web/src/server.dart';
+
+void main() async {
+  final server = Server([ServiceImpl()]);
+  await server.serve(port: 9090);
+  print('server running: ${server.port}');
+}

--- a/example/grpc-web/docker-compose.yaml
+++ b/example/grpc-web/docker-compose.yaml
@@ -1,0 +1,17 @@
+version: '3'
+
+services:
+  echo-service:
+    build:
+      context: ../../
+      dockerfile: ./example/grpc-web/docker/echo-service/Dockerfile
+    image: dart-grpcweb/echo-server
+  envoy:
+    image: dart-grpcweb/envoy
+    build:
+      context: ./docker/envoy
+      dockerfile: Dockerfile
+    ports:
+      - '8080:8080'
+    links:
+      - echo-service

--- a/example/grpc-web/docker/echo-service/Dockerfile
+++ b/example/grpc-web/docker/echo-service/Dockerfile
@@ -1,0 +1,14 @@
+FROM google/dart
+
+WORKDIR /app/example/grpc-web/
+
+ADD pubspec.* /app/
+ADD example/grpc-web/pubspec.* /app/example/grpc-web/
+
+RUN pub get --no-precompile
+ADD . /app
+RUN pub get --offline --no-precompile
+
+EXPOSE 9090
+
+ENTRYPOINT ["/usr/bin/dart", "bin/server.dart"]

--- a/example/grpc-web/docker/envoy/Dockerfile
+++ b/example/grpc-web/docker/envoy/Dockerfile
@@ -1,0 +1,5 @@
+FROM envoyproxy/envoy:latest
+COPY envoy.yaml /etc/envoy/envoy.yaml
+CMD /usr/local/bin/envoy -c /etc/envoy/envoy.yaml -l trace --log-path /tmp/envoy_info.log
+expose 9901
+expose 8080

--- a/example/grpc-web/docker/envoy/envoy.yaml
+++ b/example/grpc-web/docker/envoy/envoy.yaml
@@ -1,0 +1,43 @@
+admin:
+  access_log_path: /tmp/admin_access.log
+  address:
+    socket_address: { address: 0.0.0.0, port_value: 9901 }
+
+static_resources:
+  listeners:
+  - name: listener_0
+    address:
+      socket_address: { address: 0.0.0.0, port_value: 8080 }
+    filter_chains:
+    - filters:
+      - name: envoy.http_connection_manager
+        config:
+          codec_type: auto
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: local_service
+              domains: ["*"]
+              routes:
+              - match: { prefix: "/" }
+                route: { cluster: echo_service }
+              cors:
+                allow_origin:
+                - "*"
+                allow_methods: GET, PUT, DELETE, POST, OPTIONS
+                allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
+                max_age: "1728000"
+                expose_headers: custom-header-1,grpc-status,grpc-message
+                enabled: true
+          http_filters:
+          - name: envoy.grpc_web
+          - name: envoy.cors
+          - name: envoy.router
+  clusters:
+  - name: echo_service
+    connect_timeout: 0.25s
+    type: logical_dns
+    http2_protocol_options: {}
+    lb_policy: round_robin
+    hosts: [{ socket_address: { address: echo-service, port_value: 9090 }}]

--- a/example/grpc-web/lib/src/server.dart
+++ b/example/grpc-web/lib/src/server.dart
@@ -1,0 +1,57 @@
+import 'dart:async';
+
+import 'package:grpc/grpc.dart';
+import 'package:grpc/src/server/call.dart';
+
+import 'generated/echo.pbgrpc.dart';
+
+class ServiceImpl extends EchoServiceBase {
+  @override
+  Future<ClientStreamingEchoResponse> clientStreamingEcho(
+      ServiceCall call, Stream<ClientStreamingEchoRequest> request) {
+    // TODO: implement clientStreamingEcho
+  }
+
+  @override
+  Future<EchoResponse> echo(ServiceCall call, EchoRequest request) async {
+//    call.headers.addAll(call.clientMetadata);
+    return EchoResponse()..message = request.message;
+  }
+
+  @override
+  Future<EchoResponse> echoAbort(ServiceCall call, EchoRequest request) {
+    throw GrpcError.aborted('Aborted from server side.');
+  }
+
+  @override
+  Stream<EchoResponse> fullDuplexEcho(
+      ServiceCall call, Stream<EchoRequest> request) {}
+
+  @override
+  Stream<EchoResponse> halfDuplexEcho(
+      ServiceCall call, Stream<EchoRequest> request) {
+    // TODO: implement halfDuplexEcho
+  }
+
+  @override
+  Future<Empty> noOp(ServiceCall call, Empty request) {
+    // TODO: implement noOp
+  }
+
+  @override
+  Stream<ServerStreamingEchoResponse> serverStreamingEcho(
+      ServiceCall call, ServerStreamingEchoRequest request) async* {
+//    call.headers.addAll(call.clientMetadata);
+    for (var i = 0; i < request.messageCount; i++) {
+      yield ServerStreamingEchoResponse()..message = request.message;
+      await Future.delayed(Duration(milliseconds: request.messageInterval));
+    }
+  }
+
+  @override
+  Stream<ServerStreamingEchoResponse> serverStreamingEchoAbort(
+      ServiceCall call, ServerStreamingEchoRequest request) {
+    return Stream<ServerStreamingEchoResponse>.fromFuture(
+        Future.error(GrpcError.aborted('Aborted from server side.')));
+  }
+}

--- a/lib/src/client/connection.dart
+++ b/lib/src/client/connection.dart
@@ -21,10 +21,15 @@ import '../shared/status.dart';
 import 'call.dart';
 import 'options.dart';
 
+// ignore: uri_does_not_exist
 import 'transport/http2_transport_stub.dart'
+    // ignore: uri_does_not_exist
     if (dart.library.io) 'transport/http2_transport.dart';
+
 import 'transport/transport.dart';
+// ignore: uri_does_not_exist
 import 'transport/xhr_transport_stub.dart'
+// ignore: uri_does_not_exist
     if (dart.library.html) 'transport/xhr_transport.dart';
 
 enum ConnectionState {


### PR DESCRIPTION
After setting up the example of grpc-web took a few minutes, I figured a full dart example including the server would be great.